### PR TITLE
introduce options to `Inspect`

### DIFF
--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -16,7 +16,7 @@ export const Inspectable = <T, P = object>(
 
 				// eslint-disable-next-line @typescript-eslint/ban-types, max-len
 				for (const metadata of (Reflect.getMetadata(kInspectProperties, instance as Object) || [])) {
-					const { property, ...propertyOptions } = metadata as IInspectableMetadata;
+					const { property, options: propertyOptions } = metadata as IInspectableMetadata;
 
 					let value = (instance as unknown as P)[property as keyof P];
 
@@ -39,13 +39,15 @@ export const Inspectable = <T, P = object>(
 	}
 );
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const Inspect = (options: Record<string, any> = {}) => (
 	(
 		target: InspectedClass,
 		property: string
 	): void => {
+		// eslint-disable-next-line max-len
 		const metadata = (Reflect.getMetadata(kInspectProperties, target) || []) as IInspectableMetadata[];
-	
+
 		if (metadata.length === 0) {
 			Reflect.defineMetadata(
 				kInspectProperties,
@@ -53,10 +55,10 @@ export const Inspect = (options: Record<string, any> = {}) => (
 				target
 			);
 		}
-	
+
 		metadata.push({
 			property,
-			...options
+			options
 		});
 	}
 );

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -1,5 +1,5 @@
 import { inspectable } from './inspectable';
-import { IInspectableOptions, InspectedClass } from './types';
+import { IInspectableMetadata, IInspectableOptions, InspectedClass } from './types';
 
 export const kInspectProperties = Symbol('kInspectProperties');
 
@@ -15,8 +15,20 @@ export const Inspectable = <T, P = object>(
 				const payload = (options.serialize?.(instance) || {}) as P;
 
 				// eslint-disable-next-line @typescript-eslint/ban-types, max-len
-				for (const property of (Reflect.getMetadata(kInspectProperties, instance as Object) || [])) {
-					payload[property as keyof P] = (instance as unknown as P)[property as keyof P];
+				for (const metadata of (Reflect.getMetadata(kInspectProperties, instance as Object) || [])) {
+					const { property, ...propertyOptions } = metadata as IInspectableMetadata;
+
+					let value = (instance as unknown as P)[property as keyof P];
+
+					if (propertyOptions.nonNullable && !value) {
+						continue;
+					}
+
+					if (typeof value === 'function' && propertyOptions.execute) {
+						value = value();
+					}
+
+					payload[property as keyof P] = value;
 				}
 
 				return payload;
@@ -27,19 +39,24 @@ export const Inspectable = <T, P = object>(
 	}
 );
 
-export const Inspect = (
-	target: InspectedClass,
-	property: string
-): void => {
-	const metadata = (Reflect.getMetadata(kInspectProperties, target) || []) as string[];
-
-	if (metadata.length === 0) {
-		Reflect.defineMetadata(
-			kInspectProperties,
-			metadata,
-			target
-		);
+export const Inspect = (options: Record<string, any> = {}) => (
+	(
+		target: InspectedClass,
+		property: string
+	): void => {
+		const metadata = (Reflect.getMetadata(kInspectProperties, target) || []) as IInspectableMetadata[];
+	
+		if (metadata.length === 0) {
+			Reflect.defineMetadata(
+				kInspectProperties,
+				metadata,
+				target
+			);
+		}
+	
+		metadata.push({
+			property,
+			...options
+		});
 	}
-
-	metadata.push(property);
-};
+);

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,8 +35,7 @@ export interface IInspectOptions {
 	nonNullable?: boolean;
 }
 
-export interface IInspectableMetadata extends IInspectOptions {
+export interface IInspectableMetadata {
 	property: string;
-
-	[key: string]: any;
+	options: IInspectOptions;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,3 +26,17 @@ export interface IInspectableOptions<T, P> {
 	serialize?: InspectableSerialize<T, P>;
 	stringify?: InspectableStringify<T, P>;
 }
+
+export interface IInspectOptions {
+	/** Should we **recompute** the value if it is a function? */
+	execute?: boolean;
+
+	/** Should we **only** output the value if it is non-nullable? */
+	nonNullable?: boolean;
+}
+
+export interface IInspectableMetadata extends IInspectOptions {
+	property: string;
+
+	[key: string]: any;
+}

--- a/test/decorators.test.ts
+++ b/test/decorators.test.ts
@@ -53,8 +53,10 @@ describe('Decorators', (): void => {
 
 		Inspectable({})(Klass);
 
-		Inspect(Klass.prototype, 'method');
+		Inspect()(Klass.prototype, 'method');
 
 		expect(inspect(new Klass())).toStrictEqual('Request {\n  method: \'test\'\n}');
 	});
+
+	// TODO: add tests for `Inspect` with options
 });


### PR DESCRIPTION
currently `Inspect` is not that flexible. in fact, it completely isn't - you can't even filter the non-nullable fields from the output

this pull request resolves it--or, at least, shows the potential and the main **idea** of how to implement this